### PR TITLE
Add instructions to add 'mini_racer' gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ First edit the Gemfile .  Add these lines.
 
 gem 'jquery-rails'   
 gem 'bootstrap'   
+gem 'mini_racer'
 
 They should go in the main section, above the line
 


### PR DESCRIPTION
Without this gem, I got the following error: "Autoprefixer doesn’t support Node v6.2.2. Update it."
Found the solution here: https://stackoverflow.com/a/51980426/4979097